### PR TITLE
Add subpixel-aligned supersampling to Rift shader

### DIFF
--- a/Release/Perception/fx/OculusRift.fx
+++ b/Release/Perception/fx/OculusRift.fx
@@ -53,9 +53,6 @@ float4 SBSRift(float2 Tex : TEXCOORD0) : COLOR
   float4 tcGreen1;
   float4 tcBlue1;
 
-  // center of each subpixel; due to the screendoor "screen"
-  // inbetween them we use steps
-  // of .25 rather than .33
   float subpixelShiftR = -0.33333/1280.0f;
   float subpixelShiftB = 0.33333/1280.0f;
 


### PR DESCRIPTION
Do 4 samples per screen pixel, offset the sample origins by the
underlying subpixel positions.  In black vs white areas, this should
give greater horizontal resolution, but any miscorrected chromatic
aberration error will reduce the effect.  This also helps the chromatic
aberration correction work more accurately.

Supersampling helps a lot on its own, because the edges of the barrel
distortion are undersampled as is, and because in virieo we have 2x the
horizontal resolution to sample from (we sample from full screens rather
than half screens).

Shader will work ok when using higher/lower resolutions. It won't be
optimal with Dev Kit v2, but we should be able to do similar sampling,
taking pentile and higher resolution into account in the future.
