### PR TITLE
Fix use of uninitialized memory

### DIFF
--- a/DxProxy/DxProxy/D3DProxyDevice.cpp
+++ b/DxProxy/DxProxy/D3DProxyDevice.cpp
@@ -3361,11 +3361,11 @@ bool D3DProxyDevice::setDrawingSide(vireio::RenderPosition side)
 					result = BaseDirect3DDevice9::SetTexture(it->first, pActualLeftTexture); 
 				else 
 					result = BaseDirect3DDevice9::SetTexture(it->first, pActualRightTexture);
+
+				if (result != D3D_OK)
+					OutputDebugString("Error trying to set one of the textures while switching between active eyes for drawing.\n");
 			}
 			// else the texture is mono and doesn't need changing. It will always be set initially and then won't need changing
-
-			if (result != D3D_OK)
-				OutputDebugString("Error trying to set one of the textures while switching between active eyes for drawing.\n");
 		}
 	}
 


### PR DESCRIPTION
Move the error logging inside the scope where result is assigned.
If left outside of the scope where result is assigned, result will not be assigned if pActualRightTexture is NULL.

You might want to also add a debug string to the SetDepthStencilSurface call just before the lines modified here.