### PR TITLE
Added translation support to SharedMemoryTracker. Only 7 lines!

### DIFF
--- a/DxProxy/DxProxy/SharedMemoryTracker.cpp
+++ b/DxProxy/DxProxy/SharedMemoryTracker.cpp
@@ -91,7 +91,13 @@ int  SharedMemoryTracker::getOrientationAndPosition(float* yaw, float* pitch, fl
 	*yaw = -RADIANS_TO_DEGREES(pTrackBuf->Yaw);
 	*pitch = RADIANS_TO_DEGREES(pTrackBuf->Pitch);
 	*roll = -RADIANS_TO_DEGREES(pTrackBuf->Roll);
-
+	// Also grab position
+	primaryX = pTrackBuf->X;
+	primaryY = pTrackBuf->Y;
+	primaryZ = pTrackBuf->Z;
+	*x = primaryX;
+	*y = primaryY;
+	*z = primaryZ;
 
 	return 0; 
 }


### PR DESCRIPTION
This just updates the SharedMemoryTracker's position updating to be in line with the rotation updating. SMTVireio.dll has had unused position x/y/z slots for years; this just adds the ability to read from them.